### PR TITLE
Fix PHP 8.4 deprecations (see ADCI#15)

### DIFF
--- a/src/Exception/FirstNameNotFoundException.php
+++ b/src/Exception/FirstNameNotFoundException.php
@@ -24,7 +24,7 @@ class FirstNameNotFoundException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message ? $message : self::MESSAGE, $code, $previous);
     }

--- a/src/Exception/FlipStringException.php
+++ b/src/Exception/FlipStringException.php
@@ -26,7 +26,7 @@ class FlipStringException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($char = null, $full_name = null, $message = null, $code = 0, Throwable $previous = null)
+    public function __construct($char = null, $full_name = null, $message = null, $code = 0, ?Throwable $previous = null)
     {
         $message = sprintf(self::MESSAGE, $char, $full_name);
         parent::__construct($message, $code, $previous);

--- a/src/Exception/IncorrectInputException.php
+++ b/src/Exception/IncorrectInputException.php
@@ -25,7 +25,7 @@ class IncorrectInputException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message ? $message : self::MESSAGE, $code, $previous);
     }

--- a/src/Exception/LastNameNotFoundException.php
+++ b/src/Exception/LastNameNotFoundException.php
@@ -25,7 +25,7 @@ class LastNameNotFoundException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message ? $message : self::MESSAGE, $code, $previous);
     }

--- a/src/Exception/ManyMiddleNamesException.php
+++ b/src/Exception/ManyMiddleNamesException.php
@@ -24,7 +24,7 @@ class ManyMiddleNamesException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($count = null, $message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($count = null, $message = null, $code = 0, ?\Throwable $previous = null)
     {
         $message = sprintf(self::MESSAGE, $count);
         parent::__construct($message, $code, $previous);

--- a/src/Exception/MultipleMatchesException.php
+++ b/src/Exception/MultipleMatchesException.php
@@ -25,7 +25,7 @@ class MultipleMatchesException extends NameParsingException
     /**
      * {@inheritdoc}
      */
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message ? $message : self::MESSAGE, $code, $previous);
     }

--- a/src/Exception/NameParsingException.php
+++ b/src/Exception/NameParsingException.php
@@ -24,7 +24,7 @@ class NameParsingException extends \Exception
      * @param \Throwable|null $previous
      * Previously chained error.
      */
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
This fixes implicit nullable deprecation warnings when in an PHP 8.4 environment (see issue #15) 
